### PR TITLE
Catch up the README and confg template by adding dmID

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,5 +27,8 @@ day =
 # Channel ID for communication
 channelID =
 # If you want %, you'll need this as %%
-botPrefix = 
+botPrefix =
+# User ID (not name) of your Dungeon Master.
+# Used for sending them a summary of the upcomming session.
+dmID =
 ```

--- a/config-template.ini
+++ b/config-template.ini
@@ -10,3 +10,4 @@ day =
 channelID =
 # If you want %, you'll need this as %%
 botPrefix = 
+dmID =


### PR DESCRIPTION
Need this explanation in the README.

Add new config field.

This is the discord ID of your DM. They'll receive a summary of attendees as a direct message.