### PR TITLE
Support multi-server - breaks scheduled tasks

### DIFF
--- a/helpers.py
+++ b/helpers.py
@@ -1,3 +1,4 @@
+import re
 from enum import Enum
 from typing import Tuple, Set
 
@@ -16,66 +17,75 @@ class Tracker:
     def __init__(self, db):
         self.db = db
 
-    def get_all(self) -> Tuple[Set, Set, Set, Set]:
+    @staticmethod
+    def _builder(key: str, guild: int) -> str:
+        return f"{key}:{guild}"
+
+    def get_all(self, guild: str) -> Tuple[Set, Set, Set, Set, Set]:
         return (
-            self.get_attendees(),
-            self.get_decliners(),
-            self.get_dreamers(),
-            self.get_cancellers(),
-            self.isSkip(),
+            self.get_attendees(guild),
+            self.get_decliners(guild),
+            self.get_dreamers(guild),
+            self.get_cancellers(guild),
+            self.isSkip(guild),
         )
 
-    def reset(self) -> bool:
-        return self.db.delete(*[key.value for key in Key if "dnd-bot:unlocked" in key.value])
+    def reset(self, guild: str) -> bool:
+        matcher = re.compile(f"dnd-bot:unlocked:\w*:{guild}")
+        return self.db.delete(
+            *[
+                self._builder(key.value, guild)
+                for key in Key
+                if matcher.match(self._builder(key.value, guild))
+            ]
+        )
 
-    def skip(self) -> bool:
-        return self.db.set(Key.SKIP, "true")
+    def skip(self, guild: str) -> bool:
+        return self.db.set(self._builder(Key.SKIP, guild), "true")
 
-    def isSkip(self) -> bool:
-        return bool(self.db.get(Key.SKIP))
+    def isSkip(self, guild: str) -> bool:
+        return bool(self.db.get(self._builder(Key.SKIP, guild)))
 
-    def get_attendees(self) -> Set:
-        return self.db.smembers(Key.ATTENDEES)
+    def get_attendees(self, guild: str) -> Set:
+        return self.db.smembers(self._builder(Key.ATTENDEES, guild))
 
-    def add_attendee(self, attendee: str) -> bool:
-        return self.db.sadd(Key.ATTENDEES, attendee)
+    def add_attendee(self, guild: int, attendee: str) -> bool:
+        return self.db.sadd(self._builder(Key.ATTENDEES, guild), attendee)
 
-    def remove_attendee(self, attendee: str) -> bool:
-        return self.db.srem(Key.ATTENDEES, attendee)
+    def remove_attendee(self, guild: int, attendee: str) -> bool:
+        return self.db.srem(self._builder(Key.ATTENDEES, guild), attendee)
 
-    def add_decliner(self, decliner: str) -> bool:
-        return self.db.sadd(Key.DECLINERS, decliner)
+    def add_decliner(self, guild: int, decliner: str) -> bool:
+        return self.db.sadd(self._builder(Key.DECLINERS, guild), decliner)
 
-    def get_decliners(self) -> Set:
-        return self.db.smembers(Key.DECLINERS)
+    def get_decliners(self, guild: int) -> Set:
+        return self.db.smembers(self._builder(Key.DECLINERS, guild))
 
-    def remove_decliner(self, decliner: str) -> bool:
-        return self.db.srem(Key.DECLINERS, decliner)
+    def remove_decliner(self, guild: int, decliner: str) -> bool:
+        return self.db.srem(self._builder(Key.DECLINERS, guild), decliner)
 
-    def get_dreamers(self) -> Set:
-        return self.db.smembers(Key.DREAMERS)
+    def get_dreamers(self, guild: int) -> Set:
+        return self.db.smembers(self._builder(Key.DREAMERS, guild))
 
-    def add_dreamer(self, dreamer: str) -> bool:
-        return self.db.sadd(Key.DREAMERS, dreamer)
+    def add_dreamer(self, guild: int, dreamer: str) -> bool:
+        return self.db.sadd(self._builder(Key.DREAMERS, guild), dreamer)
 
-    def get_cancellers(self) -> Set:
-        return self.db.smembers(Key.CANCELLERS)
+    def get_cancellers(self, guild: int) -> Set:
+        return self.db.smembers(self._builder(Key.CANCELLERS, guild))
 
-    def add_canceller(self, canceller: str) -> bool:
-        return self.db.sadd(Key.CANCELLERS, canceller)
-    
-    def add_inv(self, author: int, inv: str) -> bool:
-        player_inv = self.inv_builder(author)
+    def add_canceller(self, guild: int, canceller: str) -> bool:
+        return self.db.sadd(self._builder(Key.CANCELLERS, guild), canceller)
+
+    def add_inv(self, guild: int, author: int, inv: str) -> bool:
+        player_inv = self.inv_builder(guild, author)
         return self.db.sadd(player_inv, inv)
 
-    def remove_inv(self, author, inv: str) -> bool:
+    def remove_inv(self, guild: int, author, inv: str) -> bool:
         player_inv = self.inv_builder(author)
         return self.db.srem(player_inv, inv)
-    
-    def get_inv(self, user: str) -> Set:
+
+    def get_inv(self, guild: int, user: str) -> Set:
         return self.db.smembers(self.inv_builder(user))
 
-    def inv_builder(self, author) -> str:
-        return f"{Key.INV}:{author}"
-
-    
+    def inv_builder(self, guild: int, author) -> str:
+        return f"{self._builder(Key.INV, guild)}:{author}"


### PR DESCRIPTION
We are now able to support multiple servers, though the
scheduled tasks are completely broken as we have no way
to match guilds with configurations at the moment. We
need to store guild configurations in the database
instead of in the config file. The config file should
then only include configuration to run the bot itself
and all guild-specific, or campaign-specific, config
will be done through bot commands.