### PR TITLE
Fix a bug with alert comparisons - Requires update to config

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -19,6 +19,7 @@ try:
     db_host = bot_config["db"]["host"]
     db_port = int(bot_config["db"]["port"])
     db_password = bot_config["db"]["password"]
+    alert_time = int(bot_config["alerts"]["time"])
 except KeyError:
     # Fall back to environment variables
     from os import environ
@@ -28,6 +29,7 @@ except KeyError:
     db_host = environ["dbHost"]
     db_port = int(environ["dbPort"])
     db_password = environ["dbPassword"]
+    alert_time = int(environ["alertTime"])
 
 
 # Bot init
@@ -359,7 +361,6 @@ async def _cancel(ctx):
 
 
 bt = BotTasks(bot)
-alert_time = 12
 
 
 @tasks.loop(hours=1)

--- a/config-template.ini
+++ b/config-template.ini
@@ -10,3 +10,6 @@ botPrefix =
 host =
 port =
 password =
+
+[alerts]
+time =

--- a/mongo_tracker.py
+++ b/mongo_tracker.py
@@ -235,4 +235,4 @@ class Tracker:
     def is_full_group(self, guild_id: int) -> bool:
         players = [player["id"] for player in self.get_players_for_guild(guild_id)]
         attendees = [att["id"] for att in self.get_attendees_for_guild(guild_id)]
-        return players.sort() == attendees.sort()
+        return len(players) == len(attendees)


### PR DESCRIPTION
* moved `alert_time` into the `config.ini` file; updated template.
* instead of checking for identical lists, simply check if they are equal.

**Deploying this change means that `config.ini` must be updated with the new `[alerts]` section. The value of `time` is 0-23 representing the hour that alerts should be dispatched.**