### PR TITLE
Add ability to unconfigure a guild

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -134,14 +134,14 @@ async def ask_for_day(ctx, ask):
 
 
 @bot.command()
-async def register(ctx):
-    tracker.register_player(ctx.guild.id, ctx.author)
-    await ctx.message.add_reaction("✅")
+async def unconfig(ctx):
+    tracker.rm_guild_config(ctx.guild.id)
+    await ctx.message.add_reaction("👋")
 
 
 @bot.command()
-async def unregister(ctx):
-    tracker.unregister_player(ctx.guild.id, ctx.author)
+async def register(ctx):
+    tracker.register_player(ctx.guild.id, ctx.author)
     await ctx.message.add_reaction("✅")
 
 

--- a/mongo_tracker.py
+++ b/mongo_tracker.py
@@ -204,6 +204,10 @@ class Tracker:
             upsert=True,
         )
 
+    def rm_guild_config(self, guild_id):
+        query = {"guild": guild_id}
+        return self.config.delete_one(query)
+
     def get_first_alert_configs(self, day_of_the_week: int):
         return self.config.find(
             {"config.first-alert": day_of_the_week, "config.alerts": True}


### PR DESCRIPTION
If campaign ends, we need a way to stop
asking the server for attendance.

I know the diff in `bot.py` looks weird, but register was just moved by the addition of `unconfig`.